### PR TITLE
feat: add user signup page with form validation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
 ALLOW_ORIGINS=*
-DATABASE_URL=postgres+asyncpg://user:password@host/db_name
+DATABASE_URL=postgres+asyncpg://postgres:password@localhost/futuramaapi
 TRUSTED_HOST=localhost
 SECRET_KEY=PRODUCTION-SECRET-KEY
 # Optional
@@ -16,7 +16,7 @@ EMAIL_HOST=email-host
 EMAIL_API_KEY=secret-api-key
 
 # Broker
-REDISCLOUD_URL=redis://user:password@host:6379
+REDISCLOUD_URL=redis://localhost:6379
 
 # Logging
 # Optional, if not set alerts will not be fired.
@@ -41,5 +41,5 @@ ENABLE_HTTPS_REDIRECT=false
 ENABLE_SENTRY=false
 SEND_EMAILS=true
 COUNT_API_REQUESTS=true
-USER_SIGNUP=ture
+USER_SIGNUP=true
 USER_DELETION=false

--- a/futuramaapi/routers/services/auth/get_user_signup.py
+++ b/futuramaapi/routers/services/auth/get_user_signup.py
@@ -4,16 +4,17 @@ from typing import Any
 from futuramaapi.routers.services import BaseTemplateService
 
 
-class UserAuthMessageType(StrEnum):
-    password_changed = "password_changed"  # noqa: S105
-    incorrect_login = "incorrect_login"
+class UserSignupMessageType(StrEnum):
+    signup_disabled = "signup_disabled"
+    user_exists = "user_exists"
     signup_success = "signup_success"
+    validation_error = "validation_error"
 
 
-class GetUserAuthService(BaseTemplateService):
-    template_name = "auth.html"
+class GetUserSignupService(BaseTemplateService):
+    template_name = "signup.html"
 
-    message_type: UserAuthMessageType | None
+    message_type: UserSignupMessageType | None
 
     async def get_context(self, *args, **kwargs) -> dict[str, Any]:
         return {

--- a/futuramaapi/routers/services/auth/signup_cookie_session_user.py
+++ b/futuramaapi/routers/services/auth/signup_cookie_session_user.py
@@ -1,0 +1,75 @@
+from asyncpg import UniqueViolationError
+from fastapi import status
+from fastapi.responses import RedirectResponse
+from pydantic import EmailStr, Field, SecretStr, field_validator
+from sqlalchemy import exc
+
+from futuramaapi.core import feature_flags
+from futuramaapi.db.models import UserModel
+from futuramaapi.routers.services import BaseSessionService
+from futuramaapi.routers.services.auth.get_user_signup import UserSignupMessageType
+
+
+class SignupCookieSessionUserService(BaseSessionService[RedirectResponse]):
+    name: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z\s\-']+$",
+    )
+    surname: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z\s\-']+$",
+    )
+    email: EmailStr = Field(max_length=320)
+    username: str = Field(
+        min_length=5,
+        max_length=64,
+        pattern=r"^[A-Za-z][A-Za-z0-9_]{4,}$",
+    )
+    password: SecretStr = Field(
+        min_length=8,
+        max_length=128,
+    )
+
+    @field_validator("password", mode="after")
+    @classmethod
+    def validate_password(cls, value: SecretStr, /) -> SecretStr:
+        password: str = value.get_secret_value()
+        has_letter = any(character.isalpha() for character in password)
+        has_digit = any(character.isdigit() for character in password)
+        if not has_letter or not has_digit:
+            raise ValueError("Password must contain at least one letter and one digit")
+
+        return value
+
+    async def process(self, *args, **kwargs) -> RedirectResponse:
+        if not feature_flags.user_signup:
+            return RedirectResponse(
+                url=f"/signup?messageType={UserSignupMessageType.signup_disabled}",
+                status_code=status.HTTP_302_FOUND,
+            )
+
+        user: UserModel = UserModel(
+            name=self.name,
+            surname=self.surname,
+            email=self.email,
+            username=self.username,
+            password=self.hasher.encode(self.password.get_secret_value()),
+        )
+        self.session.add(user)
+
+        try:
+            await self.session.commit()
+        except exc.IntegrityError as err:
+            if hasattr(err.orig, "sqlstate") and err.orig.sqlstate == UniqueViolationError.sqlstate:
+                return RedirectResponse(
+                    url=f"/signup?messageType={UserSignupMessageType.user_exists}",
+                    status_code=status.HTTP_302_FOUND,
+                )
+            raise
+
+        return RedirectResponse(
+            url=f"/auth?messageType={UserSignupMessageType.signup_success}",
+            status_code=status.HTTP_302_FOUND,
+        )

--- a/futuramaapi/routers/views/api.py
+++ b/futuramaapi/routers/views/api.py
@@ -1,14 +1,17 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Form, Query, Request, Response, status
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import ValidationError
 
 from futuramaapi.routers.services.about.get_about import GetAboutService
 from futuramaapi.routers.services.auth.auth_cookie_session_user import AuthCookieSessionUserService
 from futuramaapi.routers.services.auth.get_user_auth import GetUserAuthService, UserAuthMessageType
+from futuramaapi.routers.services.auth.get_user_signup import GetUserSignupService, UserSignupMessageType
 from futuramaapi.routers.services.auth.logout_cookie_session_user import LogoutCookieSessionUserService
+from futuramaapi.routers.services.auth.signup_cookie_session_user import SignupCookieSessionUserService
 from futuramaapi.routers.services.changelog.get_changelog import GetChangelogService
 from futuramaapi.routers.services.index.get_index import GetIndexService
 from futuramaapi.routers.services.sitemaps.get_sitemap import GetSiteMapService
@@ -154,6 +157,66 @@ async def logout_cookie_session_user(
             "request": request,
         },
     )
+    return await service()
+
+
+@router.get(
+    "/signup",
+    include_in_schema=False,
+    name="user_signup",
+)
+async def user_signup(
+    request: Request,
+    message_type: Annotated[
+        UserSignupMessageType | None,
+        Query(
+            alias="messageType",
+        ),
+    ] = None,
+) -> Response:
+    service: GetUserSignupService = GetUserSignupService(
+        message_type=message_type,
+        context={
+            "request": request,
+        },
+    )
+    return await service()
+
+
+@router.post(
+    "/signup",
+    include_in_schema=False,
+    name="signup_cookie_session_user",
+)
+async def signup_cookie_session_user(  # noqa: PLR0913
+    request: Request,
+    name: Annotated[str, Form()] = "",
+    surname: Annotated[str, Form()] = "",
+    email: Annotated[str, Form()] = "",
+    username: Annotated[str, Form()] = "",
+    password: Annotated[str, Form()] = "",
+) -> RedirectResponse:
+    if not all([name.strip(), surname.strip(), email.strip(), username.strip(), password]):
+        return RedirectResponse(
+            url=f"/signup?messageType={UserSignupMessageType.validation_error}",
+            status_code=status.HTTP_302_FOUND,
+        )
+    try:
+        service: SignupCookieSessionUserService = SignupCookieSessionUserService(
+            name=name,
+            surname=surname,
+            email=email,
+            username=username,
+            password=password,
+            context={
+                "request": request,
+            },
+        )
+    except ValidationError:
+        return RedirectResponse(
+            url=f"/signup?messageType={UserSignupMessageType.validation_error}",
+            status_code=status.HTTP_302_FOUND,
+        )
     return await service()
 
 

--- a/static/css/auth.css
+++ b/static/css/auth.css
@@ -83,9 +83,7 @@
   border: 1px solid #e5e7eb;
   font-size: 0.9rem;
   color: #111827;
-  transition:
-    border-color 150ms ease,
-    box-shadow 150ms ease;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
 }
 
 .auth-field input:focus {
@@ -105,9 +103,7 @@
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
-  transition:
-    background-color 150ms ease,
-    box-shadow 150ms ease,
+  transition: background-color 150ms ease, box-shadow 150ms ease,
     transform 120ms ease;
 }
 
@@ -122,7 +118,10 @@
 
 .auth-button:focus-visible {
   outline: none;
-  box-shadow:
-    0 0 0 2px #ffffff,
-    0 0 0 4px rgba(37, 99, 235, 0.4);
+  box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px rgba(37, 99, 235, 0.4);
+}
+
+.auth-footer-link {
+  margin-top: 1.5rem;
+  margin-bottom: 0;
 }

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -39,8 +39,12 @@
             class="auth-message error"
           >
             Hmm… that username or password doesn’t match our records.
-          </p>
-        {% endif %}
+          </p>        {% elif message_type == 'signup_success' %}
+          <p
+            class="auth-message success"
+          >
+            Account created! You can now sign in.
+          </p>        {% endif %}
         <p
           class="auth-subtitle"
         >
@@ -88,6 +92,12 @@
           Sign in
         </button>
       </form>
+      <p
+        class="auth-subtitle auth-footer-link"
+      >
+        Don't have an account?
+        <a href="{{ relative_path_for('user_signup') }}">Sign up</a>
+      </p>
 
     </div>
   </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -88,6 +88,16 @@
                 </form>
                 {% endif %}
               </li>
+              {% if not current_user %}
+              <li
+                class="nav-item"
+              >
+                <a
+                  class="nav-link{% if active_page == 'user_signup' %} active{% endif %}"
+                  href="{{ relative_path_for('user_signup') }}"
+                >Sign Up</a>
+              </li>
+              {% endif %}
             </ul>
           </div>
         </div>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,0 +1,174 @@
+{% extends "base.html" %}
+
+{% set active_page = "user_signup" %}
+
+{% block title %}Sign Up{% endblock %}
+
+{% block extra_styles %}
+  <link
+    href="{{ relative_path_for('static', path='/css/auth.css') }}"
+    rel="stylesheet"
+  />
+{% endblock %}
+
+{% block main_info %}{% endblock %}
+
+{% block main_content %}
+<div
+  class="container"
+>
+  <div
+    class="auth-page"
+  >
+    <div
+      class="auth-container"
+    >
+      <h1
+        class="auth-title"
+      >
+        Create an account
+      </h1>
+        {% if message_type == 'signup_disabled' %}
+          <p
+            class="auth-message warning"
+          >
+            Sign up is currently disabled. Please try again later.
+          </p>
+        {% elif message_type == 'user_exists' %}
+          <p
+            class="auth-message error"
+          >
+            An account with that username or email already exists.
+          </p>
+        {% elif message_type == 'validation_error' %}
+          <p
+            class="auth-message error"
+          >
+            Please check your input. Name and surname must contain only letters. Username must start with a letter, be at least 5 characters, and contain only letters, numbers, or underscores. Password must be at least 8 characters with both letters and numbers.
+          </p>
+        {% elif message_type == 'signup_success' %}
+          <p
+            class="auth-message success"
+          >
+            Account created! You can now <a href="{{ relative_path_for('user_auth') }}">sign in</a>.
+          </p>
+        {% endif %}
+        <p
+          class="auth-subtitle"
+        >
+          Sign up to get started with Futurama API
+        </p>
+      <form
+        method="POST"
+        action="{{ relative_path_for('signup_cookie_session_user') }}"
+      >
+        <div
+          class="auth-field"
+        >
+          <label
+            for="name"
+          >
+            Name
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            pattern="[A-Za-z\s\-']+"
+            title="Letters, spaces, hyphens, and apostrophes only"
+            minlength="1"
+            maxlength="64"
+            required
+            autofocus
+          >
+        </div>
+        <div
+          class="auth-field"
+        >
+          <label
+            for="surname"
+          >
+            Surname
+          </label>
+          <input
+            type="text"
+            id="surname"
+            name="surname"
+            pattern="[A-Za-z\s\-']+"
+            title="Letters, spaces, hyphens, and apostrophes only"
+            minlength="1"
+            maxlength="64"
+            required
+          >
+        </div>
+        <div
+          class="auth-field"
+        >
+          <label
+            for="email"
+          >
+            Email
+          </label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            maxlength="320"
+            required
+          >
+        </div>
+        <div
+          class="auth-field"
+        >
+          <label
+            for="username"
+          >
+            Username
+          </label>
+          <input
+            type="text"
+            id="username"
+            name="username"
+            pattern="[A-Za-z][A-Za-z0-9_]{4,}"
+            title="Must start with a letter, at least 5 characters, only letters, numbers, and underscores"
+            minlength="5"
+            maxlength="64"
+            required
+          >
+        </div>
+        <div
+          class="auth-field"
+        >
+          <label
+            for="password"
+          >
+            Password
+          </label>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            minlength="8"
+            maxlength="128"
+            pattern="(?=.*[A-Za-z])(?=.*\d).{8,}"
+            title="Must be at least 8 characters with both letters and numbers"
+            required
+          >
+        </div>
+        <button
+          type="submit"
+          class="auth-button"
+        >
+          Sign up
+        </button>
+      </form>
+      <p
+        class="auth-subtitle auth-footer-link"
+      >
+        Already have an account?
+        <a href="{{ relative_path_for('user_auth') }}">Sign in</a>
+      </p>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Closes #21

## Summary
Add a signup page to allow users to register via UI instead of only through the API.

## Changes
- Add signup template (`templates/signup.html`) with form fields: name, surname, email, username, password
- Add `GET /signup` route and `GetUserSignupService` to render the signup page
- Add `POST /signup` route and `SignupCookieSessionUserService` to handle form submission
- Add client-side validation (HTML patterns) and server-side validation (regex + Pydantic EmailStr)
- Handle validation errors gracefully with redirect instead of raw 422 responses
- Handle duplicate user (IntegrityError) with user-friendly error message
- Add navigation links between sign in and sign up pages
- Add `signup_success` message on auth page after successful registration