### PR TITLE
feat: implemented password reset

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,9 @@
 ALLOW_ORIGINS=*
-DATABASE_URL=postgres+asyncpg://postgres:password@localhost/futuramaapi
-TRUSTED_HOST=localhost
+BACKEND_URL=http://localhost:8080
+DATABASE_URL=postgres+asyncpg://user:password@host/db_name
+
 SECRET_KEY=PRODUCTION-SECRET-KEY
+
 # Optional
 G_TAG=G-TAG
 POOL_MAX_OVERFLOW=0
@@ -16,7 +18,7 @@ EMAIL_HOST=email-host
 EMAIL_API_KEY=secret-api-key
 
 # Broker
-REDISCLOUD_URL=redis://localhost:6379
+REDISCLOUD_URL=redis://user:password@host:6379
 
 # Logging
 # Optional, if not set alerts will not be fired.
@@ -41,5 +43,3 @@ ENABLE_HTTPS_REDIRECT=false
 ENABLE_SENTRY=false
 SEND_EMAILS=true
 COUNT_API_REQUESTS=true
-USER_SIGNUP=true
-USER_DELETION=false

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,9 @@
 ALLOW_ORIGINS=*
+BACKEND_URL=https://localhost:8080
 DATABASE_URL=postgres+asyncpg://user:password@host/db_name
-TRUSTED_HOST=localhost
+
 SECRET_KEY=PRODUCTION-SECRET-KEY
+
 # Optional
 G_TAG=G-TAG
 POOL_MAX_OVERFLOW=0

--- a/futuramaapi/core/_settings.py
+++ b/futuramaapi/core/_settings.py
@@ -7,14 +7,9 @@ from urllib.parse import urlparse
 
 from cryptography.fernet import Fernet
 from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
-from pydantic import BaseModel, EmailStr, Field, HttpUrl, PostgresDsn, RedisDsn, SecretStr
+from pydantic import BaseModel, EmailStr, Field, HttpUrl, PostgresDsn, RedisDsn, SecretStr, computed_field
 from pydantic.fields import FieldInfo
-from pydantic_settings import (
-    BaseSettings,
-    EnvSettingsSource,
-    PydanticBaseSettingsSource,
-    SettingsConfigDict,
-)
+from pydantic_settings import BaseSettings, EnvSettingsSource, PydanticBaseSettingsSource, SettingsConfigDict
 from redis.asyncio import ConnectionPool
 
 from futuramaapi.helpers.templates import TEMPLATES_PATH
@@ -188,10 +183,20 @@ class _EnvSource(EnvSettingsSource):
 
 class Settings(BaseSettings):
     allow_origins: list[str]
+    backend_url: HttpUrl
+
+    @computed_field
+    def scheme(self) -> str:
+        return self.backend_url.scheme
+
+    @computed_field
+    def trusted_host(self) -> str:
+        return self.backend_url.host
+
     database_url: PostgresDsn
     project_root: Path = Path(__file__).parent.parent.parent.resolve()
     static: Path = Path("static")
-    trusted_host: str
+
     secret_key: SecretStr
     email: EmailSettings = email_settings
     redis: RedisSettings = redis_settings
@@ -241,7 +246,7 @@ class Settings(BaseSettings):
             path = f"{self.static}/{path}" if path else f"{self.static}"
 
         return HttpUrl.build(
-            scheme="https",
+            scheme=self.scheme,
             host=self.trusted_host,
             path=path,
         )

--- a/futuramaapi/routers/services/auth/get_user_auth.py
+++ b/futuramaapi/routers/services/auth/get_user_auth.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
 from typing import Any
 
+from futuramaapi.core import settings
 from futuramaapi.routers.services import BaseTemplateService
 
 
@@ -18,4 +19,5 @@ class GetUserAuthService(BaseTemplateService):
     async def get_context(self, *args, **kwargs) -> dict[str, Any]:
         return {
             "message_type": self.message_type,
+            "backend_url": str(settings.backend_url),
         }

--- a/futuramaapi/routers/services/passwords/change_signature_requested_user_password.py
+++ b/futuramaapi/routers/services/passwords/change_signature_requested_user_password.py
@@ -1,10 +1,11 @@
+import re
 from typing import Any, ClassVar
 
 import jwt
 from fastapi import Request, status
 from fastapi.responses import RedirectResponse
 from jwt import ExpiredSignatureError, InvalidSignatureError, InvalidTokenError
-from pydantic import SecretStr
+from pydantic import Field, SecretStr, field_validator
 from sqlalchemy import Update, update
 
 from futuramaapi.core import settings
@@ -20,9 +21,24 @@ class TokenDecodeError(Exception):
 
 
 class ChangeSignatureRequestedUserPasswordService(BaseSessionService[RedirectResponse]):
-    password1: SecretStr
-    password2: SecretStr
+    password1: SecretStr = Field(
+        min_length=8,
+        max_length=128,
+    )
+    password2: SecretStr = Field(
+        min_length=8,
+        max_length=128,
+    )
     signature: str
+
+    @field_validator("password1", "password2")
+    @classmethod
+    def validate_password_strength(cls, v: SecretStr) -> SecretStr:
+        """Validate password has 8+ chars with letters and numbers."""
+        password_str = v.get_secret_value()
+        if not re.match(r"(?=.*[A-Za-z])(?=.*\d).{8,}", password_str):
+            raise ValueError("Password must contain at least 8 characters with letters and numbers")
+        return v
 
     algorithm: ClassVar[str] = "HS256"
 

--- a/futuramaapi/routers/services/passwords/get_signature_user_password_change_form.py
+++ b/futuramaapi/routers/services/passwords/get_signature_user_password_change_form.py
@@ -19,6 +19,7 @@ class TokenDecodeError(Exception):
 
 class ChangeFormError(StrEnum):
     password_mismatch = "password_mismatch"  # noqa: S105
+    invalid_password = "invalid_password"  # noqa: S105
 
 
 class GetSignatureUserPasswordChangeFormService(BaseSessionService[Response]):

--- a/futuramaapi/routers/services/users/request_change_user_password.py
+++ b/futuramaapi/routers/services/users/request_change_user_password.py
@@ -47,9 +47,11 @@ class RequestChangeUserPasswordService(BaseSessionService[None]):
         )
 
     def _get_confirmation_url(self, user: UserModel, /) -> str:
+
         url: HttpUrl = HttpUrl.build(
-            scheme="https",
+            scheme=settings.scheme,
             host=settings.trusted_host,
+            port=settings.backend_url.port,
             path="passwords/change",
             query=f"sig={self._get_signature(user)}",
         )

--- a/futuramaapi/routers/views/passwords/api.py
+++ b/futuramaapi/routers/views/passwords/api.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Form, Query, Request, Response, status
-from pydantic import SecretStr
+from pydantic import ValidationError
 from starlette.responses import RedirectResponse
 
 from futuramaapi.routers.exceptions import UnauthorizedResponse
@@ -65,18 +65,12 @@ async def get_signature_user_password_change_form(
 )
 async def change_signature_requested_user_password(
     password1: Annotated[
-        SecretStr,
-        Form(
-            min_length=8,
-            max_length=128,
-        ),
+        str,
+        Form(...),
     ],
     password2: Annotated[
-        SecretStr,
-        Form(
-            min_length=8,
-            max_length=128,
-        ),
+        str,
+        Form(...),
     ],
     sig: Annotated[
         str,
@@ -85,12 +79,18 @@ async def change_signature_requested_user_password(
     request: Request,
 ) -> RedirectResponse:
     """Change user password."""
-    service: ChangeSignatureRequestedUserPasswordService = ChangeSignatureRequestedUserPasswordService(
-        password1=password1,
-        password2=password2,
-        signature=sig,
-        context={
-            "request": request,
-        },
-    )
+    try:
+        service: ChangeSignatureRequestedUserPasswordService = ChangeSignatureRequestedUserPasswordService(
+            password1=password1,
+            password2=password2,
+            signature=sig,
+            context={
+                "request": request,
+            },
+        )
+    except ValidationError:
+        return RedirectResponse(
+            url=f"/passwords/change?sig={sig}&errorType={ChangeFormError.invalid_password}",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
     return await service()

--- a/static/css/auth.css
+++ b/static/css/auth.css
@@ -69,11 +69,22 @@
   margin-bottom: 1.25rem;
 }
 
+.auth-field-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.35rem;
+}
+
 .auth-field label {
   display: block;
   margin-bottom: 0.35rem;
   font-size: 0.8rem;
   color: #374151;
+}
+
+.auth-field-header label {
+  margin-bottom: 0;
 }
 
 .auth-field input {
@@ -93,7 +104,6 @@
 }
 
 .auth-button {
-  margin-top: 1.25rem;
   width: 100%;
   padding: 0.75rem;
   border-radius: 0.6rem;
@@ -124,4 +134,137 @@
 .auth-footer-link {
   margin-top: 1.5rem;
   margin-bottom: 0;
+}
+
+/* Forgot Password Link */
+.forgot-password-link {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.8rem;
+  color: #2563eb;
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 150ms ease;
+  font-weight: 400;
+}
+
+.forgot-password-link:hover {
+  color: #1d4ed8;
+  text-decoration: underline;
+}
+
+.forgot-password-link:focus {
+  outline: none;
+  color: #1d4ed8;
+}
+
+/* Modal Styles */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  animation: fadeIn 150ms ease-in;
+}
+
+.modal.show {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 50px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.modal-content {
+  background-color: #ffffff;
+  padding: 2rem;
+  border: none;
+  border-radius: 0.6rem;
+  width: 95%;
+  max-width: 380px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  animation: slideDown 250ms ease-out;
+  position: relative;
+}
+
+@keyframes slideDown {
+  from {
+    transform: translateY(-30px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.modal-content h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: #111827;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.modal-subtitle {
+  color: #6b7280;
+  font-size: 0.8rem;
+  margin-bottom: 1.2rem;
+  line-height: 1.5;
+}
+
+.close {
+  color: #d1d5db;
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  font-size: 1.5rem;
+  font-weight: normal;
+  cursor: pointer;
+  transition: color 150ms ease;
+  line-height: 1;
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+.close:hover,
+.close:focus {
+  color: #6b7280;
+  outline: none;
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Button disabled state */
+.auth-button:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.auth-button:disabled:hover {
+  background-color: #9ca3af;
+  box-shadow: none;
 }

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,0 +1,168 @@
+
+
+let timerInterval = null;
+
+function openForgotPasswordModal(event) {
+  event.preventDefault();
+
+  const modal = document.getElementById('forgotPasswordModal');
+  const messageDiv = document.getElementById('forgotPasswordMessage');
+  const submitButton = document.querySelector('#forgotPasswordForm button[type="submit"]');
+
+  modal.classList.add('show');
+  document.getElementById('reset-email').focus();
+
+
+  messageDiv.classList.add('hidden');
+  messageDiv.textContent = '';
+
+  const { allowed, timeRemaining } = canRequestPasswordReset();
+
+  if (!allowed) {
+    messageDiv.classList.remove('hidden');
+    messageDiv.className = 'auth-message error';
+    startCountdown(messageDiv, timeRemaining, submitButton);
+  } else {
+    submitButton.disabled = false;
+  }
+}
+
+function closeForgotPasswordModal() {
+  const modal = document.getElementById('forgotPasswordModal');
+  modal.classList.remove('show');
+
+  const messageDiv = document.getElementById('forgotPasswordMessage');
+  messageDiv.classList.add('hidden');
+  messageDiv.textContent = '';
+
+  document.getElementById('forgotPasswordForm').reset();
+  clearInterval(timerInterval);
+}
+
+function canRequestPasswordReset() {
+  const storedValue = localStorage.getItem('lastChanged');
+  const lastChanged = storedValue ? new Date(storedValue).getTime() : null;
+
+  const waitTime = 15 * 60 * 1000; // 15 minutes
+  const now = Date.now();
+
+  if (!lastChanged || isNaN(lastChanged)) {
+    return { allowed: true, timeRemaining: null };
+  }
+
+  const nextAllowed = lastChanged + waitTime;
+
+  if (now < nextAllowed) {
+    const timeRemaining = Math.ceil((nextAllowed - now) / 1000);
+    return { allowed: false, timeRemaining };
+  }
+
+  return { allowed: true, timeRemaining: null };
+}
+
+function formatTimeRemaining(seconds) {
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return minutes > 0 ? `${minutes}m ${secs}s` : `${secs}s`;
+}
+
+function startCountdown(messageDiv, seconds, submitButton) {
+  clearInterval(timerInterval);
+
+  let remaining = seconds;
+  submitButton.disabled = true;
+
+  messageDiv.textContent = `Please wait ${formatTimeRemaining(remaining)} before trying again.`;
+  timerInterval = setInterval(() => {
+    if (remaining <= 0) {
+      clearInterval(timerInterval);
+      messageDiv.textContent = 'You can now request a reset link.';
+      submitButton.disabled = false;
+      return;
+    }
+
+    messageDiv.textContent = `Please wait ${formatTimeRemaining(remaining)} before trying again.`;
+    remaining--;
+  }, 1000);
+}
+
+async function handleForgotPassword(event) {
+  event.preventDefault();
+
+  const messageDiv = document.getElementById('forgotPasswordMessage');
+  const submitButton = document.querySelector('#forgotPasswordForm button[type="submit"]');
+
+  const { allowed, timeRemaining } = canRequestPasswordReset();
+
+  if (!allowed) {
+    messageDiv.classList.remove('hidden');
+    messageDiv.className = 'auth-message error';
+    startCountdown(messageDiv, timeRemaining, submitButton);
+    return;
+  }
+
+  const email = document.getElementById('reset-email').value;
+
+  submitButton.disabled = true;
+  submitButton.textContent = 'Sending...';
+
+  console.log(BACKEND_URL)
+  try {
+    const response = await fetch(`${BACKEND_URL}api/users/passwords/request-change`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email })
+    });
+
+    messageDiv.classList.remove('hidden');
+
+    if (response.ok) {
+      messageDiv.className = 'auth-message success';
+      messageDiv.textContent = '✓ Password reset link sent! Check your email.';
+
+      // Save timestamp
+      localStorage.setItem('lastChanged', new Date().toISOString());
+
+      document.getElementById('forgotPasswordForm').reset();
+
+      setTimeout(() => closeForgotPasswordModal(), 2000);
+    } else {
+      messageDiv.className = 'auth-message error';
+      messageDiv.textContent = '✗ Unable to send reset link. Please try again.';
+    }
+  } catch (error) {
+    console.error(error);
+    messageDiv.className = 'auth-message error';
+    messageDiv.textContent = '✗ An error occurred. Please try again.';
+  } finally {
+    submitButton.disabled = false;
+    submitButton.textContent = 'Send Reset Link';
+  }
+}
+
+document.addEventListener('keydown', function(event) {
+  if (event.key === 'Escape') closeForgotPasswordModal();
+});
+
+window.onclick = function(event) {
+  const modal = document.getElementById('forgotPasswordModal');
+  if (event.target === modal) closeForgotPasswordModal();
+};
+
+// Handle URL param
+const urlParams = new URLSearchParams(window.location.search);
+const messageType = urlParams.get('messageType');
+
+if (messageType === 'password_changed') {
+  const submitButton = document.querySelector('.auth-button');
+  if (submitButton) submitButton.disabled = false;
+
+  localStorage.setItem('lastChanged', new Date().toISOString());
+
+  // Clean URL after 3s
+  setTimeout(() => {
+    const url = new URL(window.location);
+    url.searchParams.delete('messageType');
+    window.history.replaceState({}, document.title, url);
+  }, 2000);
+}

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -11,6 +11,13 @@
   />
 {% endblock %}
 
+{% block extra_scripts %}
+  <script>
+    const BACKEND_URL = "{{ backend_url }}";
+  </script>
+  <script src="{{ relative_path_for('static', path='/js/auth.js') }}"></script>
+{% endblock %}
+
 {% block main_info %}{% endblock %}
 
 {% block main_content %}
@@ -73,11 +80,16 @@
         <div
           class="auth-field"
         >
-          <label
-            for="password"
-          >
-            Password
-          </label>
+          <div class="auth-field-header">
+            <label for="password">Password</label>
+            <button
+              type="button"
+              class="forgot-password-link"
+              onclick="openForgotPasswordModal(event)"
+            >
+              Forgot password?
+            </button>
+          </div>
           <input
             type="password"
             id="password"
@@ -100,6 +112,32 @@
       </p>
 
     </div>
+  </div>
+</div>
+
+
+<div id="forgotPasswordModal" class="modal">
+  <div class="modal-content">
+    <button type="button" class="close" onclick="closeForgotPasswordModal()" title="Close">&times;</button>
+    <h2>Forgot Your Password?</h2>
+    <p class="modal-subtitle">Enter your email address and we'll send you a link to reset your password.</p>
+    
+    <form id="forgotPasswordForm" onsubmit="handleForgotPassword(event)">
+      <div class="auth-field">
+        <label for="reset-email">Email Address</label>
+        <input
+          type="email"
+          id="reset-email"
+          name="email"
+          required
+          placeholder="your@email.com"
+          autofocus
+        >
+      </div>
+      <button type="submit" class="auth-button">Send Reset Link</button>
+    </form>
+    
+    <div id="forgotPasswordMessage" class="auth-message hidden"></div>
   </div>
 </div>
 {% endblock %}

--- a/templates/password_change.html
+++ b/templates/password_change.html
@@ -36,6 +36,13 @@
               Passwords do not match.
             </p>
           {% endif %}
+          {% if error_type == 'invalid_password' %}
+            <p
+              class="auth-message error"
+            >
+              Password does not meet requirements. Use at least 8 characters with letters and numbers.
+            </p>
+          {% endif %}
           <p
             class="auth-subtitle"
           >


### PR DESCRIPTION
Closes #23 

## Summary

Add password reset functionality allowing users to request a reset link via email and securely update their password through a token-based flow.

## Changes

* Add forgot password modal in `templates/auth.html` with email input
* Add client-side rate limiting using `localStorage` to prevent repeated requests (cooldown timer)
* Add `POST /api/users/passwords/request-change` to trigger password reset flow
* Implement secure token generation and validation for password reset links
* Add password reset form (`templates/password_change.html`)
* Add `GET` route to validate token and render password change form
* Add `POST` route to update password after validation
* Handle invalid/expired tokens with user-friendly error messages
* Add success and error states with proper UI feedback
* Add redirect with `messageType=password_changed` after successful reset

## Validation

* Verified reset link request flow with cooldown timer
* Tested token validation for valid, invalid, and expired cases
* Ensured password update works correctly and invalidates old tokens
* Confirmed proper UI feedback and redirects

## Notes

* Client-side rate limiting complements backend validation (not a security boundary)
* Token-based flow designed to be stateless and secure
* UX optimized with modal-based interaction and real-time feedback
